### PR TITLE
Store response url/status/version for better transparency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,6 +1262,7 @@ dependencies = [
  "serde",
  "task-local-extensions",
  "tokio",
+ "url",
 ]
 
 [[package]]
@@ -1654,6 +1655,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ reqwest = { version = "0.11", default-features = false }
 reqwest-middleware = "0.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
 task-local-extensions = "0.1"
+url = { version = "2.2", features = ["serde"], optional = true }
 
 
 [dev-dependencies]
@@ -34,4 +35,4 @@ mockito = "0.30"
 
 [features]
 default = ["manager-cacache"]
-manager-cacache = ["cacache", "serde", "bincode"]
+manager-cacache = ["cacache", "serde", "bincode", "url"]


### PR DESCRIPTION
My attempt to integrate this crate into my code has found a problem. All `Response` objects I received had its `url` set to `"http://no.url.provided.local/"`. An HTTP cache is supposed to be pure optimization, so I believe we shouldn't be discarding any part of the response, not even peripheral parts.

This fix could easily be ported to `surf-middleware-cache`, maybe even better if some common code could be shared, but that's for another time.